### PR TITLE
Added 6.1 as the latest supported version

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -14,7 +14,7 @@ $EM_CONF[$_EXTKEY] = array(
     'version' => '0.0.1',
     'constraints' => array(
         'depends' => array(
-            'typo3' => '4.4.0-4.5.99',
+            'typo3' => '4.4.0-6.1.99',
         ),
         'conflicts' => array(),
         'suggests' => array(),


### PR DESCRIPTION
Small fix so the extension manager stops complaining about a wrong 4.7 TYPO3 Version 