### PR TITLE
[BUGFIX] make t3monitoring_client compatible with PHP 5.3

### DIFF
--- a/Classes/Slots/ExtensionManagerSlot.php
+++ b/Classes/Slots/ExtensionManagerSlot.php
@@ -25,7 +25,7 @@ class ExtensionManagerSlot
     {
         if ($extensionKey === 't3monitoring_client') {
             if (!isset($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['t3monitoring_client'])) {
-                $configuration = [];
+                $configuration = array();
             } else {
                 $configuration = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['t3monitoring_client']);
             }

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,6 +1,6 @@
 <?php
 
-$EM_CONF[$_EXTKEY] = [
+$EM_CONF[$_EXTKEY] = array(
     'title' => 'Client extension for the t3monitoring service',
     'description' => '',
     'category' => 'plugin',
@@ -12,11 +12,11 @@ $EM_CONF[$_EXTKEY] = [
     'createDirs' => '',
     'clearCacheOnLoad' => true,
     'version' => '1.0.0',
-    'constraints' => [
-        'depends' => [
+    'constraints' => array(
+        'depends' => array(
             'typo3' => '6.2.0-8.9.99',
-        ],
-        'conflicts' => [],
-        'suggests' => [],
-    ],
-];
+		),
+        'conflicts' => array(),
+        'suggests' => array(),
+	),
+);


### PR DESCRIPTION
t3monitoring_client has a minimum dependency for TYPO3 6.2 which in turn has a minimum PHP requirement for PHP 5.3. Thus EXT:t3monitoring_client should be compatible with PHP 5.3 as well.

Since ext_emconf.php misses a PHP dependency the extension crashes a TYPO3 installation during installation if the TYPO3 installation runs with TYPO3 < 5.4.