### PR TITLE
v11 compatibility

### DIFF
--- a/Classes/Provider/ExtensionProvider.php
+++ b/Classes/Provider/ExtensionProvider.php
@@ -30,7 +30,8 @@ class ExtensionProvider implements DataProviderInterface
      */
     public function get(array $data)
     {
-        $hasNewEmConfApi = VersionNumberUtility::convertVersionNumberToInteger('10.2') < VersionNumberUtility::convertVersionNumberToInteger(TYPO3_branch);
+        $isv11 = VersionNumberUtility::convertVersionNumberToInteger('11.2') < VersionNumberUtility::convertVersionNumberToInteger(TYPO3_branch);
+        $isv10 = VersionNumberUtility::convertVersionNumberToInteger('10.2') < VersionNumberUtility::convertVersionNumberToInteger(TYPO3_branch);
         $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
         $listUtility = $objectManager->get(ListUtility::class);
 
@@ -42,7 +43,14 @@ class ExtensionProvider implements DataProviderInterface
                 continue;
             }
 
-            $data['extensions'][$key] = $hasNewEmConfApi ? $emConfUtility->includeEmConf($key, $f['packagePath']) : $emConfUtility->includeEmConf($f['packagePath']);
+            if ($isv11) {
+                $data['extensions'][$key] = $emConfUtility->includeEmConf($key, $f['packagePath']);
+            } elseif ($isv10) {
+                $data['extensions'][$key] = $emConfUtility->includeEmConf($key, $f);
+            } else {
+                $data['extensions'][$key] = $emConfUtility->includeEmConf($f);
+            }
+
             $data['extensions'][$key]['isLoaded'] = (int)ExtensionManagementUtility::isLoaded($key);
         }
 

--- a/Classes/Provider/ExtensionProvider.php
+++ b/Classes/Provider/ExtensionProvider.php
@@ -42,7 +42,7 @@ class ExtensionProvider implements DataProviderInterface
                 continue;
             }
 
-            $data['extensions'][$key] = $hasNewEmConfApi ? $emConfUtility->includeEmConf($key, $f) : $emConfUtility->includeEmConf($f);
+            $data['extensions'][$key] = $hasNewEmConfApi ? $emConfUtility->includeEmConf($key, $f['packagePath']) : $emConfUtility->includeEmConf($f['packagePath']);
             $data['extensions'][$key]['isLoaded'] = (int)ExtensionManagementUtility::isLoaded($key);
         }
 

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ This extensions provides a client for the the extension **t3monitoring**.
 
 **Requirements**
 
-- TYPO3 CMS 9.5 LTS or 10.2+
+- TYPO3 CMS 9.5 LTS, 10.4 LTS or 11.3+
 - Use the branch `4-5` for support from 4.5 - 6.1
 - Use the branch `7-8` for support from 7.0 - 8.7
 


### PR DESCRIPTION
This patch provides v11 compatibility while maintaining support for TYPO3 v9 and v10.

Fixes #65 
Relates to #66 