### PR TITLE
Method doesn't exist in TYPO3 11.5 #68

### DIFF
--- a/Classes/Client.php
+++ b/Classes/Client.php
@@ -54,7 +54,9 @@ class Client
             return $response;
         }
 
-        Bootstrap::initializeBackendRouter();
+        if(method_exists(Bootstrap::class,'initializeBackendRouter')) {
+            Bootstrap::initializeBackendRouter();
+        }
         Bootstrap::loadExtTables();
 
         $data = $this->collectData();


### PR DESCRIPTION
This patch provides v11 compatibility while maintaining support for TYPO3 v9 and v10.

Fixes #68