### PR TITLE
Initialize Backend Router for TYPO3 8.7.49 ELTS

### DIFF
--- a/Classes/Client.php
+++ b/Classes/Client.php
@@ -14,6 +14,7 @@ use T3Monitor\T3monitoringClient\Client as ClientService;
 use T3Monitor\T3monitoringClient\Provider\DataProviderInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\HttpUtility;
+use TYPO3\CMS\Core\Core\Bootstrap;
 
 /**
  * Class Client
@@ -32,6 +33,8 @@ class Client
         if (!$this->checkAccess()) {
             HttpUtility::setResponseCodeAndExit(HttpUtility::HTTP_STATUS_403);
         }
+
+        Bootstrap::getInstance()->initializeBackendRouter();
 
         $data = $this->collectData();
         $data = $this->utf8Converter($data);


### PR DESCRIPTION
This is the backport of #47 for the 7-8 branch.

The monitoring of TYPO3 8.7 ELTS instances with the latest security updates (8.7.49) and the corresponding regression update ist not possible currently. This is due to the new ServerResponseCheck which makes use of the Backend Routes.

Can you push a new 1.0.x release please?