### PR TITLE
[TASK] Fallback to raw extension data when no EmConf was found

### DIFF
--- a/Classes/Provider/ExtensionProvider.php
+++ b/Classes/Provider/ExtensionProvider.php
@@ -44,7 +44,19 @@ class ExtensionProvider implements DataProviderInterface
             }
 
             if ($isv11) {
-                $data['extensions'][$key] = $emConfUtility->includeEmConf($key, $f['packagePath']);
+                // Try loading extension data from EmConf
+                $extensionData = $emConfUtility->includeEmConf($key, $f['packagePath']);
+                if (!$extensionData) {
+                    // Fallback to loading extension information from the extension itself.
+                    // FIXME: The ListUtility from TYPO3 currently does not provide the following information:
+                    //          - author
+                    //          - constraints
+                    //          - category
+                    //          - description (composer descriptions gets the title)
+                    $extensionData = $f;
+                }
+
+                $data['extensions'][$key] = $extensionData;
             } elseif ($isv10) {
                 $data['extensions'][$key] = $emConfUtility->includeEmConf($key, $f);
             } else {


### PR DESCRIPTION
The `ListUtility` that gets used to get the extensions already load already has a lot of information about the extension.

This data now gets used when no information could be fetched from the `EmConfUtility`.

The `ListUtility` does not provide all information that could be loaded from the `EmConfUtility`.

PR is marked as a draft, because it still needs proper testing in a real environment.

Fixes #74