### PR TITLE
Pass missing request object to StatusReportProvider

### DIFF
--- a/Classes/Client.php
+++ b/Classes/Client.php
@@ -15,9 +15,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use T3Monitor\T3monitoringClient\Provider\DataProviderInterface;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Core\Bootstrap;
-use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
 use TYPO3\CMS\Core\Http\Response;
-use TYPO3\CMS\Core\Http\ServerRequestFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class Client
@@ -38,7 +36,7 @@ class Client
 
         Bootstrap::loadExtTables();
 
-        $data = $this->collectData();
+        $data = $this->collectData($request);
         $data = $this->utf8Converter($data);
 
         // Generate json
@@ -78,7 +76,7 @@ class Client
      *     extra?: array,
      *   }
      */
-    protected function collectData(): array
+    protected function collectData(ServerRequestInterface $request): array
     {
         $data = [];
         /** @var class-string<DataProviderInterface>[] $classes */
@@ -87,14 +85,9 @@ class Client
         if (empty($classes)) {
             $data['error'] = 'No providers';
         } else {
-            if (!($GLOBALS['TYPO3_REQUEST'] ?? null)) {
-                $request = ServerRequestFactory::fromGlobals();
-                $GLOBALS['TYPO3_REQUEST'] = $request->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_FE);
-            }
-
             foreach ($classes as $class) {
                 /** @var DataProviderInterface $call */
-                $call = GeneralUtility::makeInstance($class);
+                $call = GeneralUtility::makeInstance($class, $request);
                 if (!$call instanceof DataProviderInterface) {
                     $data['error'] = sprintf('The class "%s" does not implement DataProviderInterface!', $class);
                     return $data;

--- a/Classes/Provider/StatusReportProvider.php
+++ b/Classes/Provider/StatusReportProvider.php
@@ -11,6 +11,7 @@ namespace T3Monitor\T3monitoringClient\Provider;
  * LICENSE.txt file that was distributed with this source code.
  */
 
+use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
@@ -18,6 +19,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class StatusReportProvider implements DataProviderInterface
 {
+    public function __construct(protected ServerRequestInterface $request) {}
+
     public function get(array $data): array
     {
         if (!ExtensionManagementUtility::isLoaded('reports')) {
@@ -30,7 +33,7 @@ class StatusReportProvider implements DataProviderInterface
             $stati = $statusReport->getSystemStatus();
         } else {
             $statusService = GeneralUtility::makeInstance(\TYPO3\CMS\Reports\Service\StatusService::class);
-            $stati = $statusService->getSystemStatus();
+            $stati = $statusService->getSystemStatus($this->request);
         }
         foreach ($stati as $providerStatuses) {
             foreach ($providerStatuses as $status) {


### PR DESCRIPTION
Hi there,

In addition to the changes suggested in #93, the StatusReportProvider requires a valid request object to function correctly in TYPO3 v14.

This PR simply passes the request object to all providers, allowing StatusReportProvider to pass the request object to `$statusService->getSystemStatus()`.

I have tested the changes of #93 and of this PR in TYPO3 14, 13 and 12.